### PR TITLE
show command names when running under MooX::Cmd

### DIFF
--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -154,6 +154,16 @@ sub parse_options {
     if ( defined $options_config{flavour} ) {
         push @flavour, { getopt_conf => $options_config{flavour} };
     }
+    if ( $class->can("command_chain") ) {
+	use DDP;
+	my @prog_name;
+	push @prog_name, Getopt::Long::Descriptive::prog_name;
+	foreach my $cmd (@{$params{command_chain}}) {
+	    my %command_names = reverse %{$cmd->command_commands};
+	    $cmd->command_name and push @prog_name, $command_names{$cmd->command_name};
+	}
+	Getopt::Long::Descriptive::prog_name(join(" ", @prog_name));
+    }
     my ( $opt, $usage ) = describe_options(
         ("USAGE: %c %o"), @options,
         [ 'help|h', "show this help message" ], @flavour


### PR DESCRIPTION
MooX::Cmd has been extended to give information about ran command. Expand
usage by that information.

While this was the easy task - users of Packager::Utils ask whether it's possible to show available sub-commands.

I can provide information about how to extract them, but none about formatting and integrating.
