### PR TITLE
Fall back to Text::LineFold if Text::WrapI18N is not available

### DIFF
--- a/lib/MooX/Options/Descriptive/Usage.pm
+++ b/lib/MooX/Options/Descriptive/Usage.pm
@@ -14,7 +14,20 @@ use strict;
 use warnings;
 # VERSION
 use feature 'say';
-use Text::WrapI18N;
+BEGIN {
+    eval {
+        require Text::WrapI18N;
+        Text::WrapI18N->import;
+    } or do {
+        require Text::LineFold;
+        *wrap = sub {
+            my $columns = $Text::WrapI18N::columns;
+            Text::LineFold->new(
+                ($columns ? (ColMax => $columns) : ()),
+            )->fold(@_)
+        };
+    }
+}
 use Term::Size::Any qw/chars/;
 use Getopt::Long::Descriptive;
 use Scalar::Util qw/blessed/;


### PR DESCRIPTION
The main reason for this change is that installing
Text::WrapI18N on some systems is impossible -- in
particular, Android's libc doesn't provide the functions
that the module needs to work.

Unfortunately, that renders MooX::Options entirely
inoperable.  Fortunately, Text::LineFold does not
suffer from this limitation and, as a bonus for UTF-8
encoded text, it usually wraps more accurately than
Text::WrapI18N, since it is really just a thin wrapper
around Unicode::LineBreak.

As an addendum to the commit message: Text::WrapI18N's last release was 11 years ago; Text::LineFold's was on June. So I think an argument could be made for switching entirely to LineFold, but that's outside the scope of this pull request.
