### PR TITLE
Support UTF-8 in man pages

### DIFF
--- a/lib/MooX/Options/Descriptive/Usage.pm
+++ b/lib/MooX/Options/Descriptive/Usage.pm
@@ -157,6 +157,10 @@ sub option_pod {
         $prog_name,
     );
 
+    if (exists $INC{'utf8.pm'}){
+      unshift @man, "=encoding UTF-8";
+    }
+
     if (defined (my $description = $options_config{description})) {
         push @man, "=head1 DESCRIPTION", $description;
     }

--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -355,7 +355,12 @@ sub options_man {
     }
 
     my $man_file = file(Path::Class::tempdir(CLEANUP => 1), 'help.pod');
-    $man_file->spew($usage->option_pod);
+    if (exists $INC{'utf8.pm'}) {
+      $man_file->spew(iomode => '>:encoding(UTF-8)', $usage->option_pod);
+    }
+    else {
+      $man_file->spew($usage->option_pod);
+    }
 
     pod2usage(-verbose => 2, -input => $man_file->stringify, -exitval => 'NOEXIT', -output => $output);
 


### PR DESCRIPTION
Tries to detect when the calling module includes `utf8.pm` and
- enables an `encoding(UTF-8)` flag with `Path::Class::File->spew()`
- inserts `=encoding UTF-8` as the first statement in the generated
  pod file

I am not a perl guru. So, this might be brittle, have unwanted side
effects and all other kinds of bad things happening, but it works
for me (TM).
