### PR TITLE
Added a better error message for isa check failures.

### DIFF
--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -230,8 +230,13 @@ sub new_with_options {
         my @missing_required = split /,\s/x, $1;
         print
           join( "\n", ( map { $_ . " is missing" } @missing_required ), '' );
-    } elsif ($@ =~ /^(.*?)\srequired/x) {
+    }
+    elsif ($@ =~ /^(.*?)\srequired/x) {
         print "$1 is missing\n";
+    }
+    elsif ($@ =~ /isa check for "(.*?)" failed: /) {
+        $@ =~ s/isa check for "(.*?)" failed: //;
+        print $@;
     }
     else {
         croak $@;

--- a/t/isa_check.t
+++ b/t/isa_check.t
@@ -1,0 +1,33 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Trap;
+
+{
+    package t;
+	use strict;
+	use warnings;
+    use Moo;
+    use MooX::Options;
+
+    option 'hero' => (
+        is     => 'ro',
+        doc    => 'this is mandatory',
+		format => 's@',
+        isa    => sub { die "boop\n" },
+    );
+
+    1;
+}
+
+{
+	local @ARGV = (qw/--hero batman/);
+    trap { my $opt = t->new_with_options(); };
+	like $trap->stdout, qr/boop/,  'stdout ok';
+	like $trap->stderr, qr/USAGE/, 'stderr ok';
+}
+
+done_testing;
+
+


### PR DESCRIPTION
When a user inputs an option which fails a Moo isa check, I was getting errors like:
```
isa check for "region" failed: boop not a valid region
 at local/lib/perl5/MooX/Cmd/Role.pm line 172.
```
This fix prints the bare die message from your isa check, followed by the usage.
