### PR TITLE
More usage options

### DIFF
--- a/lib/MooX/Options.pm
+++ b/lib/MooX/Options.pm
@@ -371,6 +371,28 @@ are expected to follow the program's options, and is entirely free-form.
 Literal "%" characters will need to be written as "%%", just like with
 "sprintf".
 
+=head1 usage_top
+
+This parameter is passed to Getopt::Long::Descriptive::describe_options() as
+the second parameter.
+
+=head1 usage_bottom
+
+This parameter is passed to Getopt::Long::Descriptive::describe_options() as
+the second to last parameter (before flavours).
+
+=head1 man_option
+
+Add a --man option.  This is true by default.
+
+=head1 help_option
+
+Add a --help option.  This is true by default.
+
+=head1 usage_option
+
+Add a --usage option.  This is true by default.
+
 =head1 OPTION PARAMETERS
 
 The keyword C<option> extend the keyword C<has> with specific parameters for the command line.

--- a/lib/MooX/Options.pm
+++ b/lib/MooX/Options.pm
@@ -83,6 +83,11 @@ sub import {
         skip_options          => [], prefer_commandline => 0,
         with_config_from_file => 0,
         usage_string          => undef,
+        usage_top             => undef,
+        usage_bottom          => undef,
+        man_option            => 1,
+        usage_option          => 1,
+        help_option           => 1,
         #long description (manual)
         description => undef, authors => [], synopsis => undef,
         @import

--- a/lib/MooX/Options/Descriptive/Usage.pm
+++ b/lib/MooX/Options/Descriptive/Usage.pm
@@ -134,6 +134,10 @@ sub option_text {
     my @message;
     my $lf = _get_line_fold();
     for my $opt(@$getopt_options) {
+        if ($opt->{desc} eq 'spacer') {
+            push @message, $opt->{spec};
+            next;
+        }
         my ($short, $format) = $opt->{spec} =~ /(?:\|(\w))?(?:=(.*?))?$/x;
         my $format_doc_str;
         $format_doc_str = $format_doc{$format} if defined $format;
@@ -247,7 +251,8 @@ sub option_short_usage {
   my $prog_name = $self->{prog_name} // Getopt::Long::Descriptive::prog_name;
 
   my @message;
-  for my $opt(@$getopt_options) {
+  for my $opt (@$getopt_options) {
+    next if $opt->{desc} eq 'spacer';
     my ($format) = $opt->{spec} =~ /(?:\|\w)?(?:=(.*?))?$/x;
     my $format_doc_str;
     $format_doc_str = $format_doc{$format} if defined $format;

--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -278,13 +278,13 @@ sub parse_options {
     # create usage str
     my $usage_str = $options_config{usage_string} // "USAGE: $prog_name %o";
 
-    my ( $opt, $usage ) = describe_options(
-        ($usage_str), @$options,
-        [ 'usage', 'show a short help message'],
-        [ 'help|h', "show a help message" ],
-        [ 'man', "show the manual" ],
-        ,@flavour
-    );
+    unshift @$options, $options_config{usage_top}          if $options_config{usage_top};
+    push @$options, ['usage', 'show a short help message'] if $options_config{usage_option};
+    push @$options, ['help|h', 'show a help message']      if $options_config{help_option};
+    push @$options, ['man', 'show the manual']             if $options_config{man_option};
+    push @$options, $options_config{usage_bottom}          if $options_config{usage_bottom};
+
+    my ( $opt, $usage ) = describe_options($usage_str, @$options, @flavour);
 
     $usage->{prog_name} = $prog_name;
     $usage->{target} = $class;
@@ -314,18 +314,15 @@ sub parse_options {
         }
     }
 
-    if (   $opt->help() || defined $params{help}
-    ) {
+    if ($opt->can('help') && $opt->help() || defined $params{help}) {
         $cmdline_params{help} = $usage;
     }
 
-    if (   $opt->man() || defined $params{man}
-    ) {
+    if ($opt->can('man') && $opt->man() || defined $params{man}) {
         $cmdline_params{man} = $usage;
     }
 
-    if (   $opt->usage() || defined $params{usage}
-    ) {
+    if ($opt->can('usage') && $opt->usage() || defined $params{usage}) {
         $cmdline_params{usage} = $usage;
     }
 

--- a/t/usage_options.t
+++ b/t/usage_options.t
@@ -9,7 +9,12 @@ use Test::Trap;
 	use strict;
 	use warnings;
     use Moo;
-    use MooX::Options usage_string => 'usage: myprogram <hi> %o';
+    use MooX::Options 
+        usage_string => 'usage: myprogram <hi> %o',
+        usage_top    => ['USAGE_TOP'],
+        usage_bottom => ['USAGE_BOTTOM'],
+        man_option   => 0,
+        usage_option => 0;
 
     option 'hero' => (
         is     => 'ro',
@@ -27,6 +32,12 @@ use Test::Trap;
         $trap->stderr, 
         qr/usage: myprogram <hi> \[-h\] \[long options/,  
         'stderr has correct usage';
+	unlike $trap->stderr, qr/--usage/,  'no --usage option';
+	unlike $trap->stderr, qr/--man/,    'no --man option';
+
+    my @lines = split "\n", $trap->stderr;
+	like $lines[3], qr/USAGE_TOP/, 'found usage_top';
+	like $lines[-1], qr/USAGE_BOTTOM/, 'found usage_bottom';
 }
 
 done_testing;


### PR DESCRIPTION
```
use MooX::Options 
   usage_top    => ['USAGE_TOP'],    # adds text after usage string but before the options text
   usage_bottom => ['USAGE_BOTTOM'], # adds text after the options text
   man_option   => 0,  # remove --man option
   help_option  => 0,  # remove --help option
   usage_option => 0;  # remove --usage option
```

See the included test for an example.
