### PR TITLE
Handle multiple autosplit options correctly

### DIFF
--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -165,16 +165,16 @@ sub _options_fix_argv {
         }
         else {
             push @new_argv, $arg_name;
-        }
-
-        # if option has an argument, we keep the argument untouched
-        if ( defined $original_long_option
-            && ( my $opt_data = $option_data->{$original_long_option} ) )
-        {
-            if ( $opt_data->{format} ) {
-                push @new_argv, shift @ARGV;
+            # if option has an argument, we keep the argument untouched
+            if ( defined $original_long_option
+                && ( my $opt_data = $option_data->{$original_long_option} ) )
+            {
+                if ( $opt_data->{format} ) {
+                    push @new_argv, shift @ARGV;
+                }
             }
         }
+
     }
 
     return @new_argv;

--- a/t/multiple-split-options.t
+++ b/t/multiple-split-options.t
@@ -1,0 +1,23 @@
+#!perl
+use Test::More;
+
+{
+
+    package TestMultipleSplitOptions;
+    use Moo;
+    use MooX::Options;
+
+    option 'opt' => ( is => 'ro', format => 'i@', autosplit => ',' );
+    option 'opt2' => ( is => 'ro', format => 'i@', autosplit => ',' );
+    1;
+}
+
+local @ARGV = ( '--opt', '1,2' , '--opt2', '3,4');
+my $opt = TestMultipleSplitOptions->new_with_options;
+
+is_deeply $opt->opt, [1,2],
+    'opt got split correctly';
+is_deeply $opt->opt2, [3,4],
+    'opt2 got split correctly';
+
+done_testing;


### PR DESCRIPTION
Problem

When the first autosplit option was processed, option handling came
out of sync (either pushing `undef` for options without arguments
or slurping up the next option).

Solution

Only push option value, when no autosplit was processed.

A test case is provided demonstrating the problem.