### PR TITLE
Show error when a value is not passed to an argument

### DIFF
--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -142,24 +142,24 @@ sub _options_fix_argv {
 
         $arg_name .= $arg_name_without_dash;
 
-        if ( my $rec = $has_to_split->{$arg_name_without_dash} ) {
-            if ( defined( $arg_values = shift @ARGV ) ) {
-                my $autorange
-                    = defined $original_long_option
-                    && exists $option_data->{$original_long_option}
-                    && $option_data->{$original_long_option}{autorange};
-                foreach my $record ( $rec->records($arg_values) ) {
+        if ( my $rec = $has_to_split->{$arg_name_without_dash}
+            and defined( $arg_values = shift @ARGV ) )
+        {
+            my $autorange
+                = defined $original_long_option
+                && exists $option_data->{$original_long_option}
+                && $option_data->{$original_long_option}{autorange};
+            foreach my $record ( $rec->records($arg_values) ) {
 
-                    #remove the quoted if exist to chain
-                    $record =~ s/^['"]|['"]$//gx;
-                    if ($autorange) {
-                        push @new_argv,
-                            map { $arg_name => $_ }
-                            _expand_autorange($record);
-                    }
-                    else {
-                        push @new_argv, $arg_name, $record;
-                    }
+                #remove the quoted if exist to chain
+                $record =~ s/^['"]|['"]$//gx;
+                if ($autorange) {
+                    push @new_argv,
+                        map { $arg_name => $_ }
+                        _expand_autorange($record);
+                }
+                else {
+                    push @new_argv, $arg_name, $record;
                 }
             }
         }
@@ -170,7 +170,8 @@ sub _options_fix_argv {
                 && ( my $opt_data = $option_data->{$original_long_option} ) )
             {
                 if ( $opt_data->{format} ) {
-                    push @new_argv, shift @ARGV;
+                    push @new_argv, shift @ARGV
+                        if defined $ARGV[0];
                 }
             }
         }

--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -143,7 +143,7 @@ sub _options_fix_argv {
         $arg_name .= $arg_name_without_dash;
 
         if ( my $rec = $has_to_split->{$arg_name_without_dash} ) {
-            if ( $arg_values = shift @ARGV ) {
+            if ( defined( $arg_values = shift @ARGV ) ) {
                 my $autorange
                     = defined $original_long_option
                     && exists $option_data->{$original_long_option}

--- a/t/autosplit_warning_on_required_param.t
+++ b/t/autosplit_warning_on_required_param.t
@@ -24,7 +24,7 @@ use Test::Trap;
 {
     local @ARGV = ('--treq');
     trap { my $opt = t->new_with_options(); };
-    like $trap->stderr,   qr/treq is missing/,      'stdout ok';
+    like $trap->stderr,   qr/^Option treq requires an argument/, 'stdout ok';
     unlike $trap->stderr, qr/Use of uninitialized/, 'stderr ok';
 }
 

--- a/t/base.st
+++ b/t/base.st
@@ -78,6 +78,29 @@ subtest "split" => sub {
     done_testing();
 };
 
+subtest "missing arg value" => sub {
+    note "missing arg value";
+    {
+        local @ARGV = ( '--needs_value' );
+        trap { t->new_with_options() };
+        is( $trap->exit, 1, "missing arg value, exit 1" );
+        like( $trap->stderr, qr/^Option needs_value requires an argument/, "error message ok for string arg" );
+    }
+    {
+        local @ARGV = ( '--split' );
+        trap { t->new_with_options() };
+        is( $trap->exit, 1, "missing arg value, exit 1" );
+        like( $trap->stderr, qr/^Option split requires an argument/, "error message ok for arg with autosplit" );
+    }
+    {
+        local @ARGV = ( '--range' );
+        trap { t->new_with_options() };
+        is( $trap->exit, 1, "missing arg value, exit 1" );
+        like( $trap->stderr, qr/^Option range requires an argument/, "error message ok for range arg" );
+    }
+    done_testing();
+};
+
 subtest "test required" => sub {
     note "test required";
 

--- a/t/base.st
+++ b/t/base.st
@@ -43,6 +43,11 @@ subtest "split" => sub {
         is_deeply( $t->split, [1], "split one arg" );
     }
     {
+        local @ARGV = ('--split=0');
+        my $t = t->new_with_options();
+        is_deeply( $t->split, [0], "split one arg with value 0" );
+    }
+    {
         local @ARGV = ( '--split=1', '--split=2' );
         my $t = t->new_with_options();
         is_deeply( $t->split, [ 1, 2 ], "split two arg" );
@@ -402,6 +407,11 @@ subtest "json format" => sub {
 
 subtest "range_complexe_str" => sub {
     note "range on complexe str";
+    {
+        local @ARGV = ('--range_str=0');
+        my $t = rg_str->new_with_options();
+        is_deeply( $t->range_str, ['0'], 'range one arg with value 0' );
+    }
     {
         local @ARGV = ('--range_str=1,2,4');
         my $t = rg_str->new_with_options();

--- a/t/mo.t
+++ b/t/mo.t
@@ -27,6 +27,7 @@ BEGIN {
     option 'split'   => ( is => 'ro', format => 'i@', autosplit => ',' );
     option 'has_default' => ( is => 'ro', default => sub {'foo'} );
     option 'range' => ( is => 'ro', format => 'i@', autorange => 1 );
+    option 'needs_value' => ( is => 'ro', format => 's' );
 
     1;
 }

--- a/t/moo.t
+++ b/t/moo.t
@@ -18,6 +18,7 @@ use Try::Tiny;
     option 'split'   => ( is => 'ro', format => 'i@', autosplit => ',' );
     option 'has_default' => ( is => 'ro', default => sub {'foo'} );
     option 'range' => ( is => 'ro', format => 'i@', autorange => 1 );
+    option 'needs_value' => ( is => 'ro', format => 's' );
 
     1;
 }

--- a/t/moose.t
+++ b/t/moose.t
@@ -26,6 +26,7 @@ BEGIN {
     option 'split'   => ( is => 'ro', format => 'i@', autosplit => ',' );
     option 'has_default' => ( is => 'ro', default => sub {'foo'} );
     option 'range' => ( is => 'ro', format => 'i@', autorange => 1 );
+    option 'needs_value' => ( is => 'ro', format => 's' );
 
     1;
 }


### PR DESCRIPTION
This fixes the issue #49. This PR also allows 0 to be passed to `split` or `range` options.

Sample code:

```perl
# argval.pl
use strict;
use warnings;

package MyApp {
    use Moo;
    use MooX::Cmd;
    use MooX::Options;

    option arg  => (
        is      => 'ro',
        format  => 's',
        default => 'default',
    );

    option split  => (
        is        => 'ro',
        autosplit => ',',
        format    => 's@',
        default   => sub { [ 'default' ] },
    );

    sub execute {
        my $self = shift;
        print "arg = " . $self->arg . "\nsplit = @{$self->split}\n";
    }
}

MyApp->new_with_cmd;

```

Sample runs:

```bash
# [Before] Value not passed for --arg
$ perl argval.pl --arg
arg = default
split = default

# [After] Value not passed for --arg
$ perl argval.pl --arg
Option arg requires an argument
USAGE: argval.pl [-h] [long options...]

    --arg=String       no doc for arg
    --split=[Strings]  no doc for split

    --usage            show a short help message
    -h                 show a compact help message
    --help             show a long help message
    --man              show the manual

#####

# [Before] 0 passed for splitting
$ perl argval.pl --split 0
arg = default
split = default

# [After] 0 passed for splitting
$ perl argval.pl --split 0
arg = default
split = 0

```