### PR TITLE
binmode utf8 broken test case

### DIFF
--- a/t/doc-utf8.t
+++ b/t/doc-utf8.t
@@ -5,6 +5,11 @@ use Carp;
 use FindBin qw/$RealBin/;
 use Try::Tiny;
 
+use utf8; #This breaks things
+
+binmode STDERR, :encoding(UTF-8);
+binmode STDOUT, :encoding(UTF-8);
+
 local $ENV{TEST_FORCE_COLUMN_SIZE} = 78;
 
 {


### PR DESCRIPTION
When enabling utf8 at source code level and setting binmode to utf8 which causes Perl to flag strings als utf8 internally, the doc output breaks.