### PR TITLE
MooX::Options: You have to "use mro ()" to get maybe::next

### DIFF
--- a/lib/MooX/Options.pm
+++ b/lib/MooX/Options.pm
@@ -114,6 +114,7 @@ sub import {
         ## no critic (ProhibitStringyEval, ErrorHandling::RequireCheckingReturnValueOfEval, ValuesAndExpressions::ProhibitImplicitNewlines)
         eval '{
         package ' . $target . ';
+        use mro ();
 
             sub _options_data {
                 my ( $class, @meta ) = @_;


### PR DESCRIPTION
On my 5.24.0 installation I get:

```
Can't locate object method "method" via package
"maybe::next" (perhaps you forgot to load "maybe::next"?) at (eval
29) line 6.

Compilation failed in require at t/mo.t line 344.
```

The full prereq dump I get is:

```
#     Capture::Tiny version is 0.44
#     Carp version is 1.40
#     Data::Record version is 0.02
#     English version is 1.10
#     File::Spec version is 3.63
#     FindBin version is 1.51
#     Getopt::Long version is 2.48
#     Getopt::Long::Descriptive version is 0.100
#     IO::Handle version is 1.36
#     IPC::Open3 version is 1.20
#     Import::Into version is 1.002005
#     JSON::MaybeXS version is 1.003007
#     Locale::TextDomain version is 1.20
#     Module::Build version is 0.422
#     Module::Metadata version is 1.000031
#     Moo version is 2.002004
#     MooX::ConfigFromFile version is 0.002
#     POSIX version is 1.65
#     Path::Class version is 0.36
#     Pod::Usage version is 1.68
#     Regexp::Common version is 2016020301
#     Role::Tiny::With version is 2.000003
#     Scalar::Util version is 1.46
#     Term::Size::Any version is 0.002
#     Test::More version is 1.001014
#     Test::Requires version is 0.10
#     Test::Trap version is 0.2.4
#     Text::LineFold version is 2012.04
#     Try::Tiny version is 0.27
#     lib version is 0.63
#     namespace::clean version is 0.27
#     overload version is 1.26
#     parent version is 0.234
#     strict version is 1.11
#     warnings version is 1.36
```

I assume the reason the author hasn't run into this is because some
version of those prereqs that wasn't being tested is at a version that
doesn't implicitly "use mro".
