### PR TITLE
Support showing the description of sub-commands in man output

### DIFF
--- a/lib/MooX/Options/Descriptive/Usage.pm
+++ b/lib/MooX/Options/Descriptive/Usage.pm
@@ -96,7 +96,7 @@ sub sub_commands_text {
       $sub_commands = $sub_commands_options;
     }
     return if !@$sub_commands;
-    return "", __("SUB COMMANDS AVAILABLE: ") . join(', ', @$sub_commands), "";
+    return "", __("SUB COMMANDS AVAILABLE: ") . join(', ', map $_->{name}, @$sub_commands), "";
 }
 
 =method text
@@ -282,7 +282,14 @@ sub option_pod {
         push @man, "=head1 AVAILABLE SUB COMMANDS";
         push @man, "=over";
         for my $sub_command (@$sub_commands) {
-            push @man, ( "=item B<" . $sub_command . "> :", $prog_name . " " . $sub_command ." [-h] [" . __("long options ...") ."]");
+            if ($sub_command->{command}->can("_options_config")
+              && defined(my $desc = { $sub_command->{command}->_options_config }->{description})) {
+              push @man, "=item B<" . $sub_command->{name} . "> : " . $desc;
+            } else {
+              push @man, "=item B<" . $sub_command->{name} . "> :";
+            }
+
+            push @man, $prog_name . " " . $sub_command->{name} ." [-h] [" . __("long options ...") ."]";
         }
         push @man, "=back";
     }

--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -236,7 +236,13 @@ sub new_with_options {
     if ( ref( my $command_commands = $params{command_commands} ) eq 'HASH' ) {
         $class->can('around')->(
             _options_sub_commands => sub {
-                return [ sort keys %$command_commands ];
+                return [
+                  map +{
+                    name => $_,
+                    command => $command_commands->{$_},
+                  },
+                  sort keys %$command_commands
+                ];
             }
         );
     }


### PR DESCRIPTION
Hi, what do you think of this? If we're using MooX::Cmd and a subcommand does `use MooX::Options description => "XXX"` then it would be nice to show the description along with the command name in the manpage for the parent command. This approach worked for me, but I would be okay with doing it differently.