### PR TITLE
MooX/Options.pm: allow enhancing attributes to option

### DIFF
--- a/lib/MooX/Options.pm
+++ b/lib/MooX/Options.pm
@@ -191,9 +191,11 @@ sub import {
             ) if $name eq $ban;
         }
 
-        $has->( $name => _filter_attributes(%attributes) );
+        my %_moo_attrs = _filter_attributes(%attributes);
+	$has->( $name => %_moo_attrs ) if %_moo_attrs;
 
-        $options_data->{$name}
+        $name =~ s/^\+//; # one enhances an attribute being an option
+	$options_data->{$name}
             = { _validate_and_filter_options(%attributes) };
 
         $apply_modifiers->();

--- a/t/option-of-attr.t
+++ b/t/option-of-attr.t
@@ -1,0 +1,36 @@
+#!perl
+
+use t::Test;
+
+{
+    package RoleOptOfAttr;
+    use Moo::Role;
+    use MooX::Options;
+
+    has 'opt' => ( is => 'ro' );
+    1;
+}
+
+{
+    package TestOptOfAttr;
+    use Moo;
+    use MooX::Options;
+
+    with "RoleOptOfAttr";
+
+    option '+opt' => ( format => 's' );
+}
+
+local @ARGV = ( '--opt', 'foo' );
+my $opt = TestOptOfAttr->new_with_options;
+
+is $opt->opt, 'foo',
+    'option of option is not changed for separated args';
+
+local @ARGV = ('--opt=bar');
+my $opt2 = TestOptOfAttr->new_with_options;
+
+is $opt2->opt, 'bar',
+    'option of option is not changed for glued args';
+
+done_testing;


### PR DESCRIPTION
Allow attributes from consumed or derived packages being enhanced ("+...") and become an option.

Unfortunately didn't the author suite install properly:
  RJBS/Dist-Zilla-6.009.tar.gz
one dependency not OK (CPAN::Uploader); additionally test harness failed
  /usr/bin/make test -- NOT OK