### PR TITLE
Fix for shortname split (pipe needs to be escaped) + test.

### DIFF
--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -65,7 +65,7 @@ sub _options_prepare_descriptive {
 
         push @{ $all_options{$name} }, $name;
         if ( $data{short} ) {
-            my @shrt_list = split( "|", $data{short} );
+            my @shrt_list = split( m/[|]/, $data{short} );
             foreach my $shrt (@shrt_list) {
                 croak
                     "There is already an option '$shrt' - can't use it to shorten '$name'"

--- a/lib/MooX/Options/Role.pm
+++ b/lib/MooX/Options/Role.pm
@@ -65,7 +65,7 @@ sub _options_prepare_descriptive {
 
         push @{ $all_options{$name} }, $name;
         if ( $data{short} ) {
-            my @shrt_list = split( m/[|]/, $data{short} );
+            my @shrt_list = split( m{ [|] }xms, $data{short} );
             foreach my $shrt (@shrt_list) {
                 croak
                     "There is already an option '$shrt' - can't use it to shorten '$name'"

--- a/t/11-moo.t
+++ b/t/11-moo.t
@@ -194,7 +194,7 @@ BEGIN {
 {
 
     package rg_str_short_common;
-    use Moose;
+    use Moo;
     use MooX::Options;
 
     option 'range_str' =>

--- a/t/27-short.t
+++ b/t/27-short.t
@@ -1,0 +1,39 @@
+#!perl
+use strict;
+use warnings all => 'FATAL';
+use Test::More;
+use Test::Trap;
+
+{
+
+    package t;
+    use Moo;
+    use MooX::Options;
+
+    option 'date_pattern' => (
+        is       => 'rw',
+        default  =>  sub { '%Y-%m-%d %H:%M:%S %Z' },
+        short    => 'dpat',
+        format   => 's',
+        doc      => 'Date pattern',
+    );
+
+    option dryrun => (
+        is       => 'rw',
+        short    => 'd',
+        doc      => 'Perform a dry run',
+    );
+
+    1;
+}
+
+my @messages;
+
+trap { t->new_with_options( h => 1 ) };
+
+ok   ! $trap->die,   'No die';
+ok   ! $trap->stdout,'No stdout';
+ok   $trap->stderr,  'stderr is set';
+like $trap->stderr, qr/show a short help message/, 'Program compiled OK. Short names are working';
+
+done_testing;

--- a/t/27-short.t
+++ b/t/27-short.t
@@ -11,17 +11,17 @@ use Test::Trap;
     use MooX::Options;
 
     option 'date_pattern' => (
-        is       => 'rw',
-        default  =>  sub { '%Y-%m-%d %H:%M:%S %Z' },
-        short    => 'dpat',
-        format   => 's',
-        doc      => 'Date pattern',
+        is      => 'rw',
+        default => sub {'%Y-%m-%d %H:%M:%S %Z'},
+        short   => 'dpat',
+        format  => 's',
+        doc     => 'Date pattern',
     );
 
     option dryrun => (
-        is       => 'rw',
-        short    => 'd',
-        doc      => 'Perform a dry run',
+        is    => 'rw',
+        short => 'd',
+        doc   => 'Perform a dry run',
     );
 
     1;
@@ -31,9 +31,10 @@ my @messages;
 
 trap { t->new_with_options( h => 1 ) };
 
-ok   ! $trap->die,   'No die';
-ok   ! $trap->stdout,'No stdout';
-ok   $trap->stderr,  'stderr is set';
-like $trap->stderr, qr/show a short help message/, 'Program compiled OK. Short names are working';
+ok !$trap->die,    'No die';
+ok !$trap->stdout, 'No stdout';
+ok $trap->stderr,   'stderr is set';
+like $trap->stderr, qr/show a short help message/,
+    'Program compiled OK. Short names are working';
 
 done_testing;


### PR DESCRIPTION
The demonstration of the bug:

    :~ bgursoy$ perl -V:version
    version='5.26.0';

    :~ bgursoy$ perl -MO=Deparse -e 'split "|"'
    split(/|/, $_, 0);
    -e syntax OK

    :~ bgursoy$ perl -MO=Deparse -e 'split "\|"'
    split(/|/, $_, 0);
    -e syntax OK

    :~ bgursoy$ perl -MO=Deparse -e 'split /\|/'
    split(/\|/, $_, 0);
    -e syntax OK

    :~ bgursoy$ perl -MO=Deparse -e 'split /[|]/'
    split(/[|]/, $_, 0);
    -e syntax OK

    :~ bgursoy$ perl -E 'say for split "|", q{foo|bar}'
    f
    o
    o
    |
    b
    a
    r

    :~ bgursoy$ perl -E 'say for split "\|", q{foo|bar}'
    f
    o
    o
    |
    b
    a
    r

    :~ bgursoy$ perl -E 'say for split /\|/, q{foo|bar}'
    foo
    bar

    :~ bgursoy$ perl -E 'say for split /[|]/, q{foo|bar}'
    foo
    bar