### PR TITLE
Adjust for Role-Tiny 2.001003: test suite and namespace::clean compatibility documentation

### DIFF
--- a/lib/MooX/Options/Manual/NamespaceClean.pod
+++ b/lib/MooX/Options/Manual/NamespaceClean.pod
@@ -12,7 +12,7 @@ be visible ...
 =head1 USAGE
 
   use MooX::Options;
-  use namespace::clean -except => [qw/_options_data _options_config/];
+  use namespace::clean -except => [qw/_options_data _options_config __ __n __p/];
 
 =head1 SEE ALSO
 

--- a/t/lib/TestNamespaceClean.pm
+++ b/t/lib/TestNamespaceClean.pm
@@ -1,7 +1,7 @@
 package TestNamespaceClean;
 use Moo;
 use MooX::Options;
-use namespace::clean -except => [qw/_options_data _options_config/];
+use namespace::clean -except => [qw/_options_data _options_config __ __n __p/];
 
 option foo => ( is => 'ro', format => 's' );
 


### PR DESCRIPTION
Upgrading `Role-Tiny` from 2.001001 to 2.001003 breaks a test case:

	t/16-namespace_clean.t ......................
	ok 1 - TestNamespaceClean is a package
	Can't locate object method "__" via package "TestNamespaceClean" at /usr/share/perl5/MooX/Options/Role.pm line 352.

One way to fix this is to ensure `namespace::clean` does not hide the methods
exported by `MooX::Locale::Passthrough`, as this commit does. But this problem
might be the symptom of a regression in `Role-Tiny`, that perhaps we should not
just paper over.

So this is mostly a RFC for now :)